### PR TITLE
3.1 & 3.2 compatibility rework + bug fixes

### DIFF
--- a/Entities/CheckpointZone/CheckpointZone.gd
+++ b/Entities/CheckpointZone/CheckpointZone.gd
@@ -43,9 +43,6 @@ onready var label = $Label
 onready var checkpoint_spawn_position = $CheckpointSpawnPositon
 onready var spawn_point_label = $CheckpointSpawnPositon/SpawnPointLabel
 
-#lookup nodes
-onready var checkpoint_manager := $"/root/CheckpointManager" as CheckpointManager
-
 var spawn_offset := Vector2(0, -1)
 
 func _ready():
@@ -61,7 +58,7 @@ func update_checkpoint():
 	
 	update_position = checkpoint_spawn_position.get_global_position() + checkpoint_spawn_position.rect_pivot_offset + spawn_offset
 	
-	checkpoint_manager.update_checkpoint_position(update_position, current_scene, get_node(target_view).name, ignore_priority, checkpoint_priority)
+	CheckpointManager.update_checkpoint_position(update_position, current_scene, get_node(target_view).name, ignore_priority, checkpoint_priority)
 	
 	if target_view == null:
 		push_warning(str(self.get_path(), ": Target new is not specified. Default value will be used."))

--- a/Entities/Enemy/Obj/MM10_WheelCutter.gd
+++ b/Entities/Enemy/Obj/MM10_WheelCutter.gd
@@ -16,7 +16,7 @@ func _ready():
 
 func _process(delta):
 	if is_on_wall():
-		pf_bhv.velocity.y -= VEL_Y_ON_WALL
+		pf_bhv.velocity.y -= VEL_Y_ON_WALL * 60 * delta
 
 func set_move_direction(dir : int):
 	move_direction = dir

--- a/Entities/Player/Player.gd
+++ b/Entities/Player/Player.gd
@@ -401,7 +401,7 @@ func check_sliding(delta : float):
 	
 	if is_sliding:
 		slide_direction_x = platformer_sprite.scale.x
-		pf_bhv.velocity.x = SLIDE_SPEED * slide_direction_x * 60 * delta
+		pf_bhv.velocity.x = SLIDE_SPEED * slide_direction_x
 		pf_bhv.left_right_key_press_time = 30 #Fix tipping toe glitch
 	
 	#Decrease slide remaining

--- a/project.godot
+++ b/project.godot
@@ -9,11 +9,6 @@
 config_version=4
 
 _global_script_classes=[ {
-"base": "Node",
-"class": "BitFlagsComparator",
-"language": "GDScript",
-"path": "res://Misc/Libraries/Utils/BitFlagsComparator/BitFlagsComparator.gd"
-}, {
 "base": "EnemyCore",
 "class": "BossCore",
 "language": "GDScript",
@@ -300,11 +295,6 @@ _global_script_classes=[ {
 "path": "res://Levels/Core/Level.gd"
 }, {
 "base": "Node",
-"class": "LevelBrightness",
-"language": "GDScript",
-"path": "res://Misc/LevelBrightnessModifier/LevelBrightness.gd"
-}, {
-"base": "Node",
 "class": "LevelBrightnessModifier",
 "language": "GDScript",
 "path": "res://Misc/LevelBrightnessModifier/LevelBrightnessModifier.gd"
@@ -365,7 +355,6 @@ _global_script_classes=[ {
 "path": "res://Misc/PaletteSpriteCore/SpriteColorPaletteData.gd"
 } ]
 _global_script_class_icons={
-"BitFlagsComparator": "",
 "BossCore": "",
 "BossHealthBar": "",
 "ButtonPlus": "",
@@ -423,7 +412,6 @@ _global_script_class_icons={
 "ItemTable": "",
 "Iterable": "",
 "Level": "",
-"LevelBrightness": "",
 "LevelBrightnessModifier": "",
 "LevelView": "",
 "LevelViewContainer": "",


### PR DESCRIPTION
This commit fixes compatibility issue with Godot 3.1 and 3.2 from two previous commits along with other bug fixes. These include:
- CheckpointZone no longer call a node using path to CheckpointManager (way too hacky)
- Fix wheel cutter flies up at a very high velocity when beside walls (Nvidia Geforce GTX)
- Fix player sliding at a very slow speed (Nvidia Geforce GTX)